### PR TITLE
Improve `HolidayJp.holiday?` and `HolidayJp.between` performance

### DIFF
--- a/lib/holiday_jp.rb
+++ b/lib/holiday_jp.rb
@@ -11,7 +11,7 @@ module HolidayJp
     holidays.holiday?(date)
   end
 
-private
+  private
 
   def self.holidays
     @@_holidays ||= Holidays.new

--- a/lib/holiday_jp.rb
+++ b/lib/holiday_jp.rb
@@ -4,13 +4,11 @@ require 'holiday_jp/holidays'
 
 module HolidayJp
   def self.between(start, last)
-    holidays.holidays.find_all do |date, _holiday|
-      start <= date && date <= last
-    end.map(&:last)
+    holidays.between(start, last)
   end
 
   def self.holiday?(date)
-    holidays.holidays[date]
+    holidays.holiday?(date)
   end
 
 private

--- a/lib/holiday_jp.rb
+++ b/lib/holiday_jp.rb
@@ -4,12 +4,18 @@ require 'holiday_jp/holidays'
 
 module HolidayJp
   def self.between(start, last)
-    Holidays.new.holidays.find_all do |date, _holiday|
+    holidays.holidays.find_all do |date, _holiday|
       start <= date && date <= last
     end.map(&:last)
   end
 
   def self.holiday?(date)
-    Holidays.new.holidays[date]
+    holidays.holidays[date]
+  end
+
+private
+
+  def self.holidays
+    @@_holidays ||= Holidays.new
   end
 end

--- a/lib/holiday_jp/holidays.rb
+++ b/lib/holiday_jp/holidays.rb
@@ -12,5 +12,15 @@ module HolidayJp
         @holidays[key] = Holiday.new(key, value)
       end
     end
+
+    def between(start, last)
+      holidays.find_all do |date, _holiday|
+        start <= date && date <= last
+      end.map(&:last)
+    end
+
+    def holiday?(date)
+      holidays[date]
+    end
   end
 end


### PR DESCRIPTION
`HolidayJp.between` and `HolidayJp.holiday?` are always create
`Holidays` instance. Now they create `Holidays` instance only once.

## background

This pull request is proposal to solve a performance issue #17. 
There was the singleton way that has been proposed in #17.
This pull reqeust proposes another solution.

Using singleton is good for performance. :+1:
However, there is an advantage about memory usage as compared to the singleton way in the following case.

The case that a program rarely needs `HolidayJp::Holidays.new.holiday?` method.

- The singleton way
A program holds `Holidays` instance during an application is alive.

- This pull request way
`Holidays` instance will be garbage collected when not needed.

What do you guys think?

## performance survey

Here is the result about performance improvement.
https://gist.github.com/ma2gedev/78fd911b2adaef120bee
